### PR TITLE
Lint: pathlib & exception-chaining small fixes

### DIFF
--- a/tools/diagnose_logging_and_routes.py
+++ b/tools/diagnose_logging_and_routes.py
@@ -147,12 +147,13 @@ def main() -> int:
         out.write(traceback.format_exc())
         code = 2
 
-    # Ensure output dir
-    import os
+    # Ensure output dir using pathlib
+    from pathlib import Path
 
-    os.makedirs(".run", exist_ok=True)
-    path = os.path.join(".run", "diagnostic-startup.txt")
-    with open(path, "w", encoding="utf-8") as f:
+    out_dir = Path(".run")
+    out_dir.mkdir(parents=True, exist_ok=True)
+    path = out_dir / "diagnostic-startup.txt"
+    with path.open("w", encoding="utf-8") as f:
         f.write(out.getvalue())
 
     print(f"Wrote diagnostic output to {path}")


### PR DESCRIPTION
This PR applies a couple of small, low-risk lint fixes:\n\n- Use pathlib for diagnostic file I/O in tools/diagnose_logging_and_routes.py.\n- Add exception chaining (raise ... from ...) in tools/download_ci_logs.py to satisfy ruff B904.\n\nThese are isolated, purely stylistic improvements to reduce CI noise. Please run CI and let me know if anything else surfaces; I'll triage any failures promptly.