### PR TITLE
ci: pin pydantic-settings to 2.11.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ alembic==1.13.2
 redis==5.0.1
 itsdangerous
 structlog
-pydantic-settings==0.5.0
+pydantic-settings==2.11.0
 passlib


### PR DESCRIPTION
Pin pydantic-settings to 2.11.0 so CI pip install finds a compatible release. This resolves collection-time import failures on GitHub Actions.