### PR TITLE
fix(requirements): pin pydantic 2.11.9 for pydantic-settings compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 jinja2==3.1.2
-pydantic[email]==2.5.0
+pydantic[email]==2.11.9
 bcrypt==4.1.1
 python-jose[cryptography]==3.3.0
 types-PyYAML==6.0.1


### PR DESCRIPTION
Pin pydantic to 2.11.9 to resolve pip dependency resolution conflicts with pydantic-settings==2.11.0 observed in CI (ERROR: ResolutionImpossible). This is a minimal change to align package versions and unblock CI runs for pr-25. Verified locally in .venv-3.11: pytest 154 passed, 1 skipped.