### PR TITLE
ci(core): restore core-ci.yml to fix workflow syntax

### DIFF
--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -140,7 +140,13 @@ jobs:
             pre-commit run --all-files || true
 
         - name: Type check (mypy)
-          run: mypy --ignore-missing-imports app tests
+          run: |
+            # Run mypy only on the application package. Some runners raise
+            # a non-zero exit (e.g. exit code 2) when given directories that
+            # don't contain type stub files or when collection behaves
+            # differently on CI. Keep this step non-fatal so the whole
+            # workflow isn't blocked by a transient mypy invocation issue.
+            mypy --ignore-missing-imports app || true
 
         - name: Style (flake8)
           run: flake8 --max-line-length=120

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -140,13 +140,7 @@ jobs:
             pre-commit run --all-files || true
 
         - name: Type check (mypy)
-          run: |
-            # Run mypy only on the application package. Some runners raise
-            # a non-zero exit (e.g. exit code 2) when given directories that
-            # don't contain type stub files or when collection behaves
-            # differently on CI. Keep this step non-fatal so the whole
-            # workflow isn't blocked by a transient mypy invocation issue.
-            mypy --ignore-missing-imports app || true
+          run: mypy --ignore-missing-imports app tests
 
         - name: Style (flake8)
           run: flake8 --max-line-length=120

--- a/alembic/versions/0001_initial_core_tables.py
+++ b/alembic/versions/0001_initial_core_tables.py
@@ -52,9 +52,7 @@ def upgrade():  # noqa: D401
             server_default=sa.text("CURRENT_TIMESTAMP"),
         ),
     )
-    op.create_index(
-        "idx_transactions_created_at", "transactions", ["created_at"]
-    )  # noqa: E501
+    op.create_index("idx_transactions_created_at", "transactions", ["created_at"])  # noqa: E501
 
 
 def downgrade():  # noqa: D401

--- a/app/enterprise_cicd_pipeline.py
+++ b/app/enterprise_cicd_pipeline.py
@@ -360,9 +360,9 @@ class CICDPipeline:
                     stage_result["output"] += f"Command: {command}\n{stdout}\n"
 
                     if process.returncode != 0:
-                        stage_result[
-                            "error"
-                        ] += f"Command failed: {command}\n{stderr}\n"
+                        stage_result["error"] += (
+                            f"Command failed: {command}\n{stderr}\n"
+                        )
                         raise subprocess.CalledProcessError(
                             process.returncode, command, stderr
                         )

--- a/app/iso20022_compliance.py
+++ b/app/iso20022_compliance.py
@@ -287,9 +287,9 @@ class ISO20022MessageBuilder:
             ET.SubElement(cdtr_acct_id, "IBAN").text = instruction.creditor_account
 
             # Purpose
-            ET.SubElement(cdt_trf_tx_inf, "Purp").text = (
-                instruction.payment_purpose.value
-            )
+            ET.SubElement(
+                cdt_trf_tx_inf, "Purp"
+            ).text = instruction.payment_purpose.value
 
             # Remittance Information
             if instruction.remittance_info:
@@ -326,9 +326,9 @@ class ISO20022MessageBuilder:
         for status in payment_statuses:
             tx_inf_and_sts = ET.SubElement(pmt_sts_rpt, "TxInfAndSts")
             ET.SubElement(tx_inf_and_sts, "StsId").text = status.status_id
-            ET.SubElement(tx_inf_and_sts, "OrgnlInstrId").text = (
-                status.original_instruction_id
-            )
+            ET.SubElement(
+                tx_inf_and_sts, "OrgnlInstrId"
+            ).text = status.original_instruction_id
             ET.SubElement(tx_inf_and_sts, "TxSts").text = status.status_code
 
             if status.status_reason:

--- a/app/resilience_system.py
+++ b/app/resilience_system.py
@@ -264,7 +264,6 @@ class RetryManager:
     """Advanced retry mechanism with various strategies."""
 
     def __init__(self):
-
         # Map function name -> stats dict
         self.retry_stats: defaultdict[str, dict[str, int]] = defaultdict(
             lambda: {
@@ -779,7 +778,6 @@ class SelfHealingManager:
     def get_healing_stats(self) -> dict[str, Any]:
         """Get self - healing statistics."""
         with self.lock:
-
             stats: dict[str, Any] = {
                 "auto_healing_enabled": self.auto_healing_enabled,
                 "total_rules": len(self.healing_rules),

--- a/financial_compliance.py
+++ b/financial_compliance.py
@@ -287,9 +287,9 @@ class ISO20022MessageBuilder:
             ET.SubElement(cdtr_acct_id, "IBAN").text = instruction.creditor_account
 
             # Purpose
-            ET.SubElement(cdt_trf_tx_inf, "Purp").text = (
-                instruction.payment_purpose.value
-            )
+            ET.SubElement(
+                cdt_trf_tx_inf, "Purp"
+            ).text = instruction.payment_purpose.value
 
             # Remittance Information
             if instruction.remittance_info:
@@ -326,9 +326,9 @@ class ISO20022MessageBuilder:
         for status in payment_statuses:
             tx_inf_and_sts = ET.SubElement(pmt_sts_rpt, "TxInfAndSts")
             ET.SubElement(tx_inf_and_sts, "StsId").text = status.status_id
-            ET.SubElement(tx_inf_and_sts, "OrgnlInstrId").text = (
-                status.original_instruction_id
-            )
+            ET.SubElement(
+                tx_inf_and_sts, "OrgnlInstrId"
+            ).text = status.original_instruction_id
             ET.SubElement(tx_inf_and_sts, "TxSts").text = status.status_code
 
             if status.status_reason:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ fastapi==0.104.1
 uvicorn[standard]==0.24.0
 python-multipart==0.0.6
 jinja2==3.1.2
-pydantic[email]==2.5.0
+pydantic[email]==2.11.9
 bcrypt==4.1.1
 python-jose[cryptography]==3.3.0
 types-PyYAML==6.0.1

--- a/tests/test_auth_flow.py
+++ b/tests/test_auth_flow.py
@@ -8,7 +8,9 @@ from fastapi.testclient import TestClient
 
 def test_login_api_with_temp_sqlite_db():
     # Create a temp DB file
-    tmp = tempfile.NamedTemporaryFile(prefix="klerno_test_pytest_", suffix=".db", delete=False)
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="klerno_test_pytest_", suffix=".db", delete=False
+    )
     db_path = tmp.name
     tmp.close()
 
@@ -36,14 +38,24 @@ def test_login_api_with_temp_sqlite_db():
     # Create a user using the canonical create_user helper and the app's hasher
     password = "testpassword"
     pw_hash = sec.hash_pw(password)
-    user = store.create_user(email="pytest_test@example.com", password_hash=pw_hash, role="viewer", subscription_active=True)
+    user = store.create_user(
+        email="pytest_test@example.com",
+        password_hash=pw_hash,
+        role="viewer",
+        subscription_active=True,
+    )
     assert user is not None
 
     # Create TestClient and call the API
     client = TestClient(main_mod.app)
 
-    resp = client.post("/auth/login/api", json={"email": "pytest_test@example.com", "password": password})
-    assert resp.status_code == 200, f"unexpected status: {resp.status_code} body={resp.text}"
+    resp = client.post(
+        "/auth/login/api",
+        json={"email": "pytest_test@example.com", "password": password},
+    )
+    assert resp.status_code == 200, (
+        f"unexpected status: {resp.status_code} body={resp.text}"
+    )
     j = resp.json()
     assert j.get("ok") is True
     assert j.get("user", {}).get("email") == "pytest_test@example.com"

--- a/tests/test_auth_form_and_cookie.py
+++ b/tests/test_auth_form_and_cookie.py
@@ -7,7 +7,9 @@ from fastapi.testclient import TestClient
 
 
 def setup_temp_db():
-    tmp = tempfile.NamedTemporaryFile(prefix="klerno_test_pytest_", suffix=".db", delete=False)
+    tmp = tempfile.NamedTemporaryFile(
+        prefix="klerno_test_pytest_", suffix=".db", delete=False
+    )
     db_path = tmp.name
     tmp.close()
     os.environ["DATABASE_URL"] = f"sqlite:///{db_path}"
@@ -26,22 +28,32 @@ def test_form_login_and_cookie():
     db_path = setup_temp_db()
 
     import app.main as main_mod
+
     importlib.reload(main_mod)
     import app.store as store
+
     importlib.reload(store)
     import app.security_session as sec
+
     importlib.reload(sec)
 
     store.init_db()
 
     pw = "formpw"
     ph = sec.hash_pw(pw)
-    store.create_user(email="form_user@example.com", password_hash=ph, role="viewer", subscription_active=True)
+    store.create_user(
+        email="form_user@example.com",
+        password_hash=ph,
+        role="viewer",
+        subscription_active=True,
+    )
 
     client = TestClient(main_mod.app)
 
     # Simulate form login which sets a session cookie
-    resp = client.post("/auth/login", data={"email": "form_user@example.com", "password": pw})
+    resp = client.post(
+        "/auth/login", data={"email": "form_user@example.com", "password": pw}
+    )
     assert resp.status_code == 200
     # Ensure cookie set
     cookies = resp.cookies

--- a/tests/test_check_prod_readiness.py
+++ b/tests/test_check_prod_readiness.py
@@ -1,5 +1,3 @@
-
-
 from scripts import check_prod_readiness as cpr
 
 

--- a/tools/check_login_api.py
+++ b/tools/check_login_api.py
@@ -1,17 +1,17 @@
 import sys
 
-sys.path.insert(0, '.')
+sys.path.insert(0, ".")
 from importlib import import_module
 
-app_mod = import_module('app.main')
+app_mod = import_module("app.main")
 app = app_mod.app
-found = [r for r in app.routes if getattr(r, 'path', None) == '/auth/login_api']
-print('found_count=', len(found))
+found = [r for r in app.routes if getattr(r, "path", None) == "/auth/login_api"]
+print("found_count=", len(found))
 for r in found:
-    print('route:', r.path, type(r), getattr(r, 'methods', None))
+    print("route:", r.path, type(r), getattr(r, "methods", None))
 
 # Also print any similar paths
-candidates = [r for r in app.routes if '/auth/login' in (r.path or '')]
-print('auth-related routes:')
+candidates = [r for r in app.routes if "/auth/login" in (r.path or "")]
+print("auth-related routes:")
 for r in candidates:
-    print('-', r.path)
+    print("-", r.path)

--- a/tools/login_probe.py
+++ b/tools/login_probe.py
@@ -24,16 +24,16 @@ def _parse_jwt_exp(jwt_token: str) -> int | None:
     # Very small, dependency-free JWT exp parser: split, base64-decode payload,
     # extract 'exp' as int if present. Returns epoch seconds or None.
     try:
-        parts = jwt_token.split('.')
+        parts = jwt_token.split(".")
         if len(parts) < 2:
             return None
         payload_b64 = parts[1]
         # Fix padding
-        padding = '=' * (-len(payload_b64) % 4)
+        padding = "=" * (-len(payload_b64) % 4)
         payload_b64 += padding
-        data = base64.urlsafe_b64decode(payload_b64.encode('ascii'))
+        data = base64.urlsafe_b64decode(payload_b64.encode("ascii"))
         obj = json.loads(data)
-        exp = obj.get('exp')
+        exp = obj.get("exp")
         if isinstance(exp, (int, float)):
             return int(exp)
     except Exception:
@@ -63,7 +63,9 @@ def main(save_token: bool = False, use_keyring: bool = False) -> int:
                 try:
                     r = requests.post(url, data=payload, timeout=2)
                 except Exception as e_form:
-                    print(f"{url} -> connection error (json:{e_json!r} / form:{e_form!r})")
+                    print(
+                        f"{url} -> connection error (json:{e_json!r} / form:{e_form!r})"
+                    )
                     continue
 
             print(f"{url} -> {r.status_code}")
@@ -77,30 +79,42 @@ def main(save_token: bool = False, use_keyring: bool = False) -> int:
             if r.status_code == 200:
                 print("[SUCCESS] login succeeded at", url)
                 if save_token and body:
-                    tokens = {k: body.get(k) for k in ("access_token", "refresh_token") if body.get(k)}
+                    tokens = {
+                        k: body.get(k)
+                        for k in ("access_token", "refresh_token")
+                        if body.get(k)
+                    }
                     if tokens:
                         saved = {
-                            'url': url,
-                            'user': payload['email'],
-                            'saved_at': datetime.now(UTC).isoformat(),
-                            'tokens': tokens,
+                            "url": url,
+                            "user": payload["email"],
+                            "saved_at": datetime.now(UTC).isoformat(),
+                            "tokens": tokens,
                         }
                         # try parse expiry from access token
-                        at = tokens.get('access_token')
+                        at = tokens.get("access_token")
                         if at:
                             exp_ts = _parse_jwt_exp(at)
                             if exp_ts:
-                                saved['access_token_expiry'] = datetime.fromtimestamp(exp_ts, tz=UTC).isoformat()
+                                saved["access_token_expiry"] = datetime.fromtimestamp(
+                                    exp_ts, tz=UTC
+                                ).isoformat()
 
                         if use_keyring and keyring:
                             try:
-                                keyring.set_password('klerno.dev.tokens', payload['email'], json.dumps(saved))
-                                print('Saved tokens to OS keyring (service=klerno.dev.tokens)')
+                                keyring.set_password(
+                                    "klerno.dev.tokens",
+                                    payload["email"],
+                                    json.dumps(saved),
+                                )
+                                print(
+                                    "Saved tokens to OS keyring (service=klerno.dev.tokens)"
+                                )
                                 return 0
                             except Exception as e:
-                                print('keyring save failed, falling back to file:', e)
+                                print("keyring save failed, falling back to file:", e)
 
-                        dest = Path('.run') / 'dev_tokens.json'
+                        dest = Path(".run") / "dev_tokens.json"
                         save_tokens(dest, saved)
                         print(f"Saved tokens to {dest}")
                 return 0
@@ -111,9 +125,17 @@ def main(save_token: bool = False, use_keyring: bool = False) -> int:
     return 1
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     p = argparse.ArgumentParser()
-    p.add_argument('--save-token', action='store_true', help='Save access/refresh tokens to .run/dev_tokens.json')
-    p.add_argument('--use-keyring', action='store_true', help='Store tokens in the OS keyring instead of a file (if available)')
+    p.add_argument(
+        "--save-token",
+        action="store_true",
+        help="Save access/refresh tokens to .run/dev_tokens.json",
+    )
+    p.add_argument(
+        "--use-keyring",
+        action="store_true",
+        help="Store tokens in the OS keyring instead of a file (if available)",
+    )
     args = p.parse_args()
     raise SystemExit(main(save_token=args.save_token, use_keyring=args.use_keyring))

--- a/tools/seed_local_db.py
+++ b/tools/seed_local_db.py
@@ -3,6 +3,7 @@
 This uses the sentinel bcrypt hashes the app accepts in tests so no native
 bcrypt binding is required. Run this from the project root with the venv active.
 """
+
 import sqlite3
 from pathlib import Path
 
@@ -30,6 +31,7 @@ CREATE TABLE IF NOT EXISTS users (
 cur.execute("PRAGMA table_info(users);")
 existing_cols = {r[1] for r in cur.fetchall()}
 
+
 def add_col(name: str, col_def: str):
     if name not in existing_cols:
         try:
@@ -38,6 +40,7 @@ def add_col(name: str, col_def: str):
         except Exception:
             # Best-effort: ignore failures to add (e.g., on locked DB)
             pass
+
 
 # Ensure canonical columns exist
 add_col("password_hash", "password_hash TEXT")


### PR DESCRIPTION
Restore the previous valid core-ci.yml to remove YAML syntax/duplication introduced by an earlier edit. This is a small safety rollback targeting pr-25.