### PR TITLE
ci: ensure DB schema before tests (init_db_if_needed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,19 @@ jobs:
       - name: Test with coverage (pytest)
         env:
           PYTHONWARNINGS: ignore
-        run: pytest -q --cov=app --cov-report=xml
+        run: |
+          # Ensure a fallback DATABASE_URL is available for tests and persist it
+          mkdir -p ./data || true
+          if [ -z "$DATABASE_URL" ]; then
+            echo "DATABASE_URL=sqlite:///./data/klerno.db" >> $GITHUB_ENV
+          else
+            # persist whatever DATABASE_URL the job has so later steps see it
+            echo "DATABASE_URL=$DATABASE_URL" >> $GITHUB_ENV
+          fi
+          # Install sqlalchemy for the initializer and run repo-provided init
+          python -m pip install --upgrade pip sqlalchemy >/dev/null || true
+          python -m scripts.init_db_if_needed || true
+          pytest -q --cov=app --cov-report=xml
 
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -75,19 +75,18 @@ jobs:
           python -m pip install pytest coverage >/dev/null || true
 
       - name: Ensure fallback DB tables exist
-        # Run lightweight initializer to create legacy-compatible tables
-        # (uses scripts/init_db_if_needed.py which the repo already provides).
+        # Run lightweight initializer to create legacy-compatible tables and
+        # persist a fallback DATABASE_URL so later steps (pytest) see it.
         run: |
-          # Ensure SQLAlchemy is available for the initializer
           python -m pip install --upgrade pip sqlalchemy >/dev/null || true
-          # Make sure a ./data dir exists for sqlite fallbacks
           mkdir -p ./data || true
-          # If CI didn't set DATABASE_URL, fall back to local sqlite DB used by tests
           if [ -z "$DATABASE_URL" ]; then
-            export DATABASE_URL="sqlite:///./data/klerno.db"
+            echo "DATABASE_URL=sqlite:///./data/klerno.db" >> $GITHUB_ENV
+          else
+            echo "DATABASE_URL=$DATABASE_URL" >> $GITHUB_ENV
           fi
-          # Run the repo-provided initializer; ignore failures so tests can still run and surface errors
-          python scripts/init_db_if_needed.py || true
+          # Run the repo-provided initializer (module form)
+          python -m scripts.init_db_if_needed || true
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/core-ci.yml
+++ b/.github/workflows/core-ci.yml
@@ -74,6 +74,21 @@ jobs:
           if [ -f dev-requirements.txt ]; then python -m pip install -r dev-requirements.txt >/dev/null || true; fi
           python -m pip install pytest coverage >/dev/null || true
 
+      - name: Ensure fallback DB tables exist
+        # Run lightweight initializer to create legacy-compatible tables
+        # (uses scripts/init_db_if_needed.py which the repo already provides).
+        run: |
+          # Ensure SQLAlchemy is available for the initializer
+          python -m pip install --upgrade pip sqlalchemy >/dev/null || true
+          # Make sure a ./data dir exists for sqlite fallbacks
+          mkdir -p ./data || true
+          # If CI didn't set DATABASE_URL, fall back to local sqlite DB used by tests
+          if [ -z "$DATABASE_URL" ]; then
+            export DATABASE_URL="sqlite:///./data/klerno.db"
+          fi
+          # Run the repo-provided initializer; ignore failures so tests can still run and surface errors
+          python scripts/init_db_if_needed.py || true
+
       - name: Run tests with coverage
         run: |
           set -o pipefail || true

--- a/.github/workflows/enterprise.yml
+++ b/.github/workflows/enterprise.yml
@@ -100,7 +100,9 @@ jobs:
           mkdir -p .run
           # If CI didn't set DATABASE_URL, fall back to a local sqlite file.
           if [ -z "$DATABASE_URL" ]; then
-            export DATABASE_URL="sqlite:///./data/klerno.db"
+            echo "DATABASE_URL=sqlite:///./data/klerno.db" >> $GITHUB_ENV
+          else
+            echo "DATABASE_URL=$DATABASE_URL" >> $GITHUB_ENV
           fi
           # Run alembic pointing explicitly at the repo alembic.ini so the
           # migrations use the correct configuration in CI. Capture verbose
@@ -123,7 +125,7 @@ jobs:
         # a differently named table or partially failed.
         run: |
           python -m pip install --upgrade pip sqlalchemy
-          python scripts/init_db_if_needed.py || true
+          python -m scripts.init_db_if_needed || true
 
       - name: Run Enterprise Application Tests
         run: |

--- a/api_load_testing.py
+++ b/api_load_testing.py
@@ -19,7 +19,7 @@ import os
 import random
 import statistics
 import time
-from typing import Any
+from typing import Any, cast
 
 import httpx
 
@@ -45,7 +45,7 @@ async def run_load(n: int = 1000) -> dict[str, Any]:
     first_id: int | None = None
 
     async with httpx.AsyncClient(
-        transport=httpx.ASGITransport(app=app), base_url="http://test"
+        transport=httpx.ASGITransport(app=cast(Any, app)), base_url="http://test"
     ) as client:
         # Warm-up health check
         r = await client.get("/health")

--- a/conftest.py
+++ b/conftest.py
@@ -38,8 +38,15 @@ def ensure_db_initialized() -> None:
         # Import and call the repository initializer helper (no duplication).
         from scripts import init_db_if_needed as _init
 
-        _init.main(url)
+        # Log what we're initializing so CI output can explain failures.
+        print(f"[conftest.ensure_db_initialized] DATABASE_URL={url}")
+
+        rc = _init.main(url)
+        print(f"[conftest.ensure_db_initialized] init_db_if_needed.main returned {rc}")
+
+        # If the helper reported an error, raise so CI fails with a clear cause.
+        if rc != 0:
+            raise RuntimeError(f"init_db_if_needed reported non-zero exit: {rc}")
     except Exception:
-        # If initialization fails, allow tests to run so failures surface in
-        # CI logs; don't raise here to avoid masking helpful pytest output.
-        pass
+        # Re-raise so CI log captures the traceback for triage.
+        raise

--- a/conftest.py
+++ b/conftest.py
@@ -86,7 +86,9 @@ def ensure_per_test_sqlite_initialized(monkeypatch, request) -> None:
         # test assertions remain the primary failure signal, but log rc.
         rc = _init.main(url)
         if rc != 0:
-            print(f"[conftest.ensure_per_test_sqlite_initialized] init returned {rc} for {url}")
+            print(
+                f"[conftest.ensure_per_test_sqlite_initialized] init returned {rc} for {url}"
+            )
     except Exception as exc:  # pragma: no cover - best-effort logging
         print(f"[conftest.ensure_per_test_sqlite_initialized] exception: {exc}")
         # Do not raise here; let tests fail on their own assertions.

--- a/conftest.py
+++ b/conftest.py
@@ -14,3 +14,32 @@ pytest_plugins = ["asyncio"]
 def disable_rate_limiting_for_tests(monkeypatch) -> None:
     """Disable rate limiting for all tests."""
     monkeypatch.setenv("ENABLE_RATE_LIMIT", "false")
+
+
+@pytest.fixture(scope="session", autouse=True)
+def ensure_db_initialized() -> None:
+    """Ensure the fallback database has core tables before any tests run.
+
+    This reuses the repository's `scripts/init_db_if_needed.py` helper so we
+    don't duplicate initialization logic. It sets a default `DATABASE_URL`
+    pointing at `./data/klerno.db` when one isn't provided and calls the
+    script's `main()` function.
+    """
+    import os
+    from pathlib import Path
+
+    try:
+        # Ensure ./data exists for the default sqlite file path.
+        Path("./data").mkdir(exist_ok=True)
+
+        url = os.getenv("DATABASE_URL") or "sqlite:///./data/klerno.db"
+        os.environ.setdefault("DATABASE_URL", url)
+
+        # Import and call the repository initializer helper (no duplication).
+        from scripts import init_db_if_needed as _init
+
+        _init.main(url)
+    except Exception:
+        # If initialization fails, allow tests to run so failures surface in
+        # CI logs; don't raise here to avoid masking helpful pytest output.
+        pass


### PR DESCRIPTION
Run the repo-provided scripts/init_db_if_needed.py in CI before pytest to ensure legacy-compatible tables (txs, users) exist. This avoids flaky missing-table failures in CI without duplicating code.